### PR TITLE
User posts page now only displays user posts.

### DIFF
--- a/rareapi/models/posts.py
+++ b/rareapi/models/posts.py
@@ -11,3 +11,11 @@ class Posts(models.Model):
     image_url = models.CharField(max_length=100)
     content = models.CharField(max_length=200)
     approved = models.BooleanField()
+
+    @property
+    def IsAuthor(self):
+        return self.__IsAuthor
+
+    @IsAuthor.setter
+    def IsAuthor(self, value):
+        self.__IsAuthor = value

--- a/rareapi/views/postTag.py
+++ b/rareapi/views/postTag.py
@@ -55,7 +55,7 @@ class PostTags(ViewSet):
             #
             # The `2` at the end of the route becomes `pk`
             postTag = PostTag.objects.get(pk=pk)
-            serializer = postTagSerializer(tag, context={'request': request})
+            serializer = postTagSerializer(postTag, context={'request': request})
             return Response(serializer.data)
         except Exception as ex:
             return HttpResponseServerError(ex)

--- a/rareapi/views/posts.py
+++ b/rareapi/views/posts.py
@@ -142,6 +142,15 @@ class Post(ViewSet):
         # if category is not None:
         #     post = post.filter(category_id=category)
 
+        for p in post:
+            p.IsAuthor = None
+
+            try:
+                RareUser.objects.get(user=request.auth.user, pk=p.rare_user.id)
+                p.IsAuthor = True
+            except RareUser.DoesNotExist:
+                p.IsAuthor = False
+
         serializer = PostSerializer(
             post, many=True, context={'request': request})
         return Response(serializer.data)
@@ -171,7 +180,7 @@ class PostSerializer(serializers.HyperlinkedModelSerializer):
     
     class Meta:
         model = Posts
-        fields =('id', 'category', 'title', 'rare_user', 'publication_date', 'image_url', 'content', 'approved')
+        fields =('id', 'category', 'title', 'rare_user', 'publication_date', 'image_url', 'content', 'approved', 'IsAuthor')
         depth = 1
 
     


### PR DESCRIPTION
When you click the User Posts link on the nav bar, you will be taken to a page where you can only see posts by the user you are currently logged in as. 

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I ran the front and back end and observed that the filter is working properly by logging in as a user and clicking the link to all posts and then single post. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
